### PR TITLE
Server and client can send TCP messages back and forth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test.py
 auctionsystem/__pycache__/
 auctionsystem/tcp/__pycache__/
 auctionsystem/udp/__pycache__/
+offers_file.pickle

--- a/auctionsystem/protocol.py
+++ b/auctionsystem/protocol.py
@@ -36,9 +36,9 @@ class REASON(Enum):
     ACTIVE_BID = (b'ACTIVE_BID',
                   'Client is currently leading with the highest bid for at least one item')
     OFFER_LIMIT = (b'OFFER_LIMIT',
-                   'Client cannot have more than 3 items offered for bidding simultaneously')
+                   'Client cannot have more than 3 bidding_items offered for bidding simultaneously')
     NO_VALID_BIDS = (b'NO_VALID_BIDS',
-                     'No valid bid exceeding the items minimum purchase price was made on the offered item')
+                     'No valid bid exceeding the bidding_items minimum purchase price was made on the offered item')
 
     def __init__(self, val, string):
         self.val = val

--- a/auctionsystem/udp/server.py
+++ b/auctionsystem/udp/server.py
@@ -5,12 +5,12 @@ import sys
 
 class UDPServer:
 
-    def __init__(self, loop, handle_receive_cb, port_number = 8888):
+    def __init__(self, loop, handle_receive_cb, port_number=8888):
         self._closed = False
         self._socket = self._get_udp_server_socket(port_number)
 
         # Start listeners for read/write events
-        loop.create_task(self._handle_receive(loop, handle_receive_cb))
+        self.task = loop.create_task(self._handle_receive(loop, handle_receive_cb))
 
     def send(self, data, addr):
         self._socket.sendto(data, addr)
@@ -19,10 +19,11 @@ class UDPServer:
     def close_socket(self):
         print('Closing socket', file=sys.stderr)
         self._closed = True
+        self.task.cancel()
         self._socket.close()
 
     @staticmethod
-    def _get_udp_server_socket(port_number = 8888):
+    def _get_udp_server_socket(port_number=8888):
         # Create a UDP socket
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)


### PR DESCRIPTION
- Added a recover parameter in the AuctionServer so that it doesn't reuse the values saved to file unless the flag is set to true
- Fixed a bug where offers file was not getting saved to file properly
- We only signal BID_OVER for every client other than the winner
- make_data_to_send automatically casts every arg to a string

Comments for commit a89a855e8f7934fc6e9de2de930596be4624d825 that were never mentioned:
- TCP servers are a dictionary accessed by item_number, so one AuctionServer will have one TCP server for each active offer
- Offers are saved to file using pickle
- Replaced the multilayer asynchronous message passing paradigm (with asyncio queues) by just sending the handle_receive callback into the TCP/UDP servers
- Made a helper function send_udp_message that can send any udp message using a single line (so I could probably remove functions like send_registered and replace them inline with send_udp_message)
- An async biding_counter goes off for 5 minutes after a new offer is sent to all clients. It then handles closing an auction and messaging the winner and seller
- Implemented the TCP server using asyncio and callbacks from AuctionServer. It has a connection class because it has to support multiple connections to different clients.
- tcp_server is similar to udp_server except it uses a message queue for its send function to ensure that messages are sent in the order that they're intended to be sent in

- TODO: Need to take into account how we recover from server crash if there are active offers