### PR TITLE
Client implementations and server fix

### DIFF
--- a/auctionsystem/client.py
+++ b/auctionsystem/client.py
@@ -102,7 +102,6 @@ class AuctionClient:
         self.confirm_acknowledgement(req_num)
         # TODO: REMOVE THIS, CONTROLLER STUFF SHOULD BE ELSEWHERE
         desc = ''.join(random.choices(string.ascii_letters + string.digits, k=30))  # Random letters and numbers
-        self.send_register(name, ip_addr, port_num)
         self.send_offer(self.client_name, self.udp_client.address[0], desc, random.randint(0, 300))
         print('received registered')
 

--- a/auctionsystem/protocol.py
+++ b/auctionsystem/protocol.py
@@ -44,3 +44,5 @@ class REASON(Enum):
         self.val = val
         self.str = string
 
+class AUCTION_CONSTS:
+    OFFER_LIMIT = 3

--- a/auctionsystem/server.py
+++ b/auctionsystem/server.py
@@ -180,7 +180,8 @@ class AuctionServer:
             validity = REASON.NOT_REGISTERED
 
         # The client is only allowed to make 3 simultaneous offers
-        if len([offer for key, offer in self.offers.items() if name == offer['offered_by']]) > AUCTION_CONSTS.OFFER_LIMIT:
+        if len([offer for key, offer in self.offers.items() if name == offer['offered_by']]) \
+                >= AUCTION_CONSTS.OFFER_LIMIT:
             validity = REASON.OFFER_LIMIT
 
         # TODO: what if ip_address or data is damaged?

--- a/auctionsystem/server.py
+++ b/auctionsystem/server.py
@@ -1,6 +1,6 @@
 from auctionsystem.udp.server import UDPServer
 from auctionsystem.tcp.server import TCPServer
-from auctionsystem.protocol import MESSAGE, REASON, PROTOCOL
+from auctionsystem.protocol import MESSAGE, REASON, PROTOCOL, AUCTION_CONSTS
 import queue
 import asyncio
 import pickle
@@ -180,7 +180,7 @@ class AuctionServer:
             validity = REASON.NOT_REGISTERED
 
         # The client is only allowed to make 3 simultaneous offers
-        if len([offer for key, offer in self.offers.items() if name == offer['offered_by']]) > 3:
+        if len([offer for key, offer in self.offers.items() if name == offer['offered_by']]) > AUCTION_CONSTS.OFFER_LIMIT:
             validity = REASON.OFFER_LIMIT
 
         # TODO: what if ip_address or data is damaged?

--- a/auctionsystem/server.py
+++ b/auctionsystem/server.py
@@ -253,7 +253,7 @@ class AuctionServer:
             winner_addr = offer['highest_bid_addr']
             bid_amount = offer['highest_bid']
             data_to_send = self.make_data_to_send(MESSAGE.WIN.value, item_num, winner_name,
-                                                  winner_addr[0], winner_addr[1], bid_amount )
+                                                  winner_addr[0], winner_addr[1], bid_amount)
             self.tcp_servers[item_num].conn[winner_addr].send(data_to_send)
 
             # Signal that the bidding is over to all the other clients
@@ -290,7 +290,7 @@ class AuctionServer:
         if int(amount) > int(offer['highest_bid']):
             offer['highest_bid'] = amount
             offer['highest_bid_by'] = name
-            offer['highest_bid_addr'] = (addr[0], str(addr[1]))
+            offer['highest_bid_addr'] = (addr[0], addr[1])
             # Inform all auction participants for this item that there is a new highest bid
             self.sendall_highest_bid(item_num, amount)
 

--- a/auctionsystem/tcp/client.py
+++ b/auctionsystem/tcp/client.py
@@ -11,7 +11,7 @@ class TCPClient:
         self._send_queue = asyncio.Queue(loop=loop)
 
         self.tasks = []
-        loop.create_task(self.initialize_client(loop, handle_receive_cb))
+        self.tasks.append(loop.create_task(self.initialize_client(loop, handle_receive_cb)))
 
     def __del__(self):
         self.close_connections()

--- a/auctionsystem/test/network_test.py
+++ b/auctionsystem/test/network_test.py
@@ -3,23 +3,27 @@ from multiprocessing import Process
 from auctionsystem import client, server
 
 
-# class NetworkTests(unittest.TestCase):
-#     pass
+class NetworkTests(unittest.TestCase):
 
+    @staticmethod
+    def test_basic_run():
+        process_server = Process(target=NetworkTests.start_server)
+        process_client = Process(target=NetworkTests.start_client)
 
-def start_server():
-    server.AuctionServer()
+        process_server.start()
+        process_client.start()
 
+    # Utility methods
 
-def start_client():
-    client.AuctionClient()
+    @staticmethod
+    def start_server():
+        server.AuctionServer()
+
+    @staticmethod
+    def start_client():
+        client.AuctionClient()
 
 
 if __name__ == '__main__':
-    process_server = Process(target=start_server)
-    process_client = Process(target=start_client)
-
-    process_server.start()
-    process_client.start()
-
+    unittest.main()
 

--- a/auctionsystem/test/network_test.py
+++ b/auctionsystem/test/network_test.py
@@ -1,0 +1,25 @@
+import unittest
+from multiprocessing import Process
+from auctionsystem import client, server
+
+
+# class NetworkTests(unittest.TestCase):
+#     pass
+
+
+def start_server():
+    server.AuctionServer()
+
+
+def start_client():
+    client.AuctionClient()
+
+
+if __name__ == '__main__':
+    process_server = Process(target=start_server)
+    process_client = Process(target=start_client)
+
+    process_server.start()
+    process_client.start()
+
+


### PR DESCRIPTION
Client
- Implemented resending of messages, keeps track of request number better
- Handled case of bad IP and other scenarios in most of the messages by resending the message -> the acknowledge method returns the message arguments to simplify this
- Handled case of receiving an item that was already existing in bidding items
- Handled dereg confirmed -> closes all connections

Server
- There was an issue with sending the winner message and ending the auction due to a misplaced int to string conversion of the port number when adding the bidder's address to the dictionary. Removed that "str()" call and it works now.