### PR TITLE
Server crash restores item number and many fixes for ended auctions.

### DIFF
--- a/auctionsystem/client.py
+++ b/auctionsystem/client.py
@@ -199,7 +199,7 @@ class AuctionClient:
         # Item has been sold to another client
         self.bidding_ended(item_num)
         if self.gui_cb:
-            self.gui_cb(MESSAGE.WIN, item_num, amount)
+            self.gui_cb(MESSAGE.BID_OVER, item_num, amount)
         else:
             print("You are NOT the winner of item {}, bought for {}!".format(item_num, amount))
 

--- a/auctionsystem/client.py
+++ b/auctionsystem/client.py
@@ -219,7 +219,7 @@ class AuctionClient:
         reason_str = REASON.get_reason_str(reason)
 
         if self.gui_cb:
-            self.gui_cb(MESSAGE.NOT_SOLD, reason_str)
+            self.gui_cb(MESSAGE.NOT_SOLD, item_num, reason_str)
         else:
             print('Item {}, was not sold because {}'.format(item_num, reason.str))
 

--- a/auctionsystem/server.py
+++ b/auctionsystem/server.py
@@ -38,8 +38,11 @@ class AuctionServer:
             self.offers = dict()
 
         # Keep track of item numbers to ensure they're all unique
-        # TODO: This should probably be saved to file in self.offers to ensure that we don't restart from 0 if recover
         self.next_item_number = 0
+        if recover:
+            if len(self.offers) > 0:
+                # Set the item number to the largest item number in the recovered offers file + 1
+                self.next_item_number = sorted([int(item_num) for item_num in self.offers.keys()])[-1] + 1
 
         # Setup sockets
         self.udp_server = UDPServer(self.loop, self.handle_receive)

--- a/auctionsystem/server.py
+++ b/auctionsystem/server.py
@@ -245,7 +245,7 @@ class AuctionServer:
 
     async def bidding_counter(self, item_num):
         # Start the bidding counter and handle the events at the end of the bidding period
-        bidding_period = 10 # 60*5  # in seconds
+        bidding_period = 60*5  # in seconds
         await asyncio.sleep(bidding_period)
 
         # Get the seller's address and prepare to send them a message whether or not the item was sold

--- a/auctionsystem/server.py
+++ b/auctionsystem/server.py
@@ -245,7 +245,7 @@ class AuctionServer:
 
     async def bidding_counter(self, item_num):
         # Start the bidding counter and handle the events at the end of the bidding period
-        bidding_period = 60*5  # in seconds
+        bidding_period = 10 # 60*5  # in seconds
         await asyncio.sleep(bidding_period)
 
         # Get the seller's address and prepare to send them a message whether or not the item was sold

--- a/gui/auction_client_gui.py
+++ b/gui/auction_client_gui.py
@@ -117,7 +117,6 @@ class AuctionClientGui(tk.Frame):
         elif command == MESSAGE.SOLD_TO:
             self.rcv_sold_to(item_num=args[0], name=args[1], ip_addr=args[2], port=args[3], amount=args[4])
         elif command == MESSAGE.NOT_SOLD:
-            print('HERE: {0} {1}'.format(args[0], args[1]))
             self.rcv_not_sold(item_num=args[0], reason=args[1])
 
     # Message Functions
@@ -197,8 +196,10 @@ class AuctionClientGui(tk.Frame):
         self.offers_history[item_num] = {'min': min_price, 'status': 'Currently being auctioned for.', 'desc': desc}
 
     def add_offer_history_to_list(self, item_num, status):
-        self.offers_history[item_num]['status'] = status
-        self.my_offers_panel.add_new_ended_item(item_num)
+        self.items_list_panel.remove_item(item_num)
+        if item_num in self.offers_history:
+            self.offers_history[item_num]['status'] = status
+            self.my_offers_panel.add_new_ended_item(item_num)
 
     async def run_tk_loop(self, interval=0.05):
         try:

--- a/gui/auction_client_gui.py
+++ b/gui/auction_client_gui.py
@@ -117,6 +117,7 @@ class AuctionClientGui(tk.Frame):
         elif command == MESSAGE.SOLD_TO:
             self.rcv_sold_to(item_num=args[0], name=args[1], ip_addr=args[2], port=args[3], amount=args[4])
         elif command == MESSAGE.NOT_SOLD:
+            print('HERE: {0} {1}'.format(args[0], args[1]))
             self.rcv_not_sold(item_num=args[0], reason=args[1])
 
     # Message Functions

--- a/gui/gui_helper.py
+++ b/gui/gui_helper.py
@@ -1,3 +1,4 @@
+import tkinter as tk
 import string
 import random
 from auctionsystem.protocol import *
@@ -33,3 +34,13 @@ def get_truncated_text(textobj, length):
 def gen_rand_str(length):
     rand_name = ''.join(random.choices(string.ascii_letters + string.digits, k=length))
     return rand_name
+
+
+def delete_listbox_item(item_to_remove, list_box):
+    items = list_box.get(0, tk.END)
+    item_index = items.index(item_to_remove)
+    list_box.delete(item_index)
+
+
+def item_in_listbox(item_to_check, list_box):
+    return item_to_check in list_box.get(0, tk.END)

--- a/gui/items_list_panel.py
+++ b/gui/items_list_panel.py
@@ -32,12 +32,21 @@ class ItemsListPanel(tk.Frame):
 
     def selection_cb(self, event):
         if self.items_listbox.curselection():
-            self.selected_item = event.widget.get(event.widget.curselection()[0])
+            self.selected_item = self.items_listbox.get(self.items_listbox.curselection())
             # See AuctionClientGui's bidding_item_sel_cb function
             self.list_sel_cb(self.selected_item)
 
     def add_new_item(self, item_num):
         self.items_listbox.insert(0, item_num)
+
+    def remove_item(self, item_num):
+
+        if helper.item_in_listbox(item_num, self.items_listbox):
+
+            if self.items_listbox.curselection() == item_num:
+                self.new_item_panel.clear()
+
+            helper.delete_listbox_item(item_num, self.items_listbox)
 
     def clear(self):
         self.items_listbox.delete(0, tk.END)

--- a/gui/my_offers_panel.py
+++ b/gui/my_offers_panel.py
@@ -64,8 +64,7 @@ class MyOffersPanel(tk.Frame):
         # if it is in that list
         ongoing_offers = self.ongoing_offers_listbox.get(0, tk.END)
         if item_num in ongoing_offers:
-            offer_ended_index = ongoing_offers.index(item_num)
-            self.ongoing_offers_listbox.delete(offer_ended_index)
+            helper.delete_listbox_item(item_num, self.ongoing_offers_listbox)
 
         self.ended_offers_listbox.insert(tk.END, item_num)
 


### PR DESCRIPTION
- Server now restores item number to the next one in recovery mode
- The not sold to callback for the client gui is called and works as it should
- Fixed the issues with ending auctions; now offered items are actually removed and put in the ended auctions list with the appropriate messages
- Bid over callback is called for GUI with the correct message type (from Message.WIN to Message.BID_OVER) - offer is no longer added twice to the ended auctions list
- The server was sending bid over to all the clients only when there was a winner, fixed it so it sends bid over to all the clients regardless