### PR TITLE
Dereg fixes

### DIFF
--- a/auctionsystem/client.py
+++ b/auctionsystem/client.py
@@ -125,6 +125,7 @@ class AuctionClient:
 
         self.tcp_clients.clear()  # Should close all of the connections
         self.udp_client.close_socket()
+        # self.udp_client = None
 
         if self.gui_update_cb:
             self.gui_update_cb(MESSAGE.DEREGISTER_CONFIRM)
@@ -205,6 +206,7 @@ class AuctionClient:
             print("You are NOT the winner of item {}, bought for {}!".format(item_num, amount))
 
     def bidding_ended(self, item_num):
+        self.tcp_clients[item_num].close_connections()
         del self.tcp_clients[item_num]
         del self.bidding_items[item_num]
 

--- a/auctionsystem/client.py
+++ b/auctionsystem/client.py
@@ -171,7 +171,7 @@ class AuctionClient:
             self.send_bid(item_num, self.bidding_items[item_num]['last_bid'])
         else:
             self.bidding_items[item_num] = {'item_num': item_num, 'port_num': port, 'desc': desc, 'min': min_price,
-                                            'highest': False, 'highest_bid': min_price, 'last_bid': 0}
+                                            'highest': False, 'highest_bid': min_price, 'last_bid': '0'}
             self.tcp_clients[item_num] = TCPClient(self.loop, self.handle_receive, (self.server_address[0], int(port)))
 
             if self.gui_update_cb:

--- a/auctionsystem/server.py
+++ b/auctionsystem/server.py
@@ -70,8 +70,12 @@ class AuctionServer:
                 self.sendall_new_item(self.offers[item_num])
 
         # Run the event loop
-        self.loop.run_forever()
-        self.loop.close()
+        try:
+            self.loop.run_forever()
+            self.loop.close()
+        except KeyboardInterrupt:
+            self.loop.close()
+            sys.exit()
 
     def __del__(self):
         self.udp_server.close_socket()

--- a/auctionsystem/server.py
+++ b/auctionsystem/server.py
@@ -7,6 +7,7 @@ import pickle
 import logging
 import sys
 
+
 class AuctionServer:
     def __init__(self, recover=False):
 

--- a/auctionsystem/tcp/client.py
+++ b/auctionsystem/tcp/client.py
@@ -10,6 +10,7 @@ class TCPClient:
         self._socket = self.get_tcp_client_socket()
         self._send_queue = asyncio.Queue(loop=loop)
 
+        self._closed = False
         self.tasks = []
         self.tasks.append(loop.create_task(self.initialize_client(loop, handle_receive_cb)))
 
@@ -24,8 +25,9 @@ class TCPClient:
     def close_connections(self):
         print('Closing connections to this TCP client', file=sys.stderr)
         # Stop listening for new data to send or receive
-        for task in self.tasks:
-            task.close()
+        # for task in self.tasks:
+        #     task.cancel()
+        self._closed = True
 
         # Close this client's socket
         self._socket.close()
@@ -62,13 +64,17 @@ class TCPClient:
             sys.exit()
 
     async def _handle_receive(self, loop, handle_receive_cb):
-        while True:
-            data = await loop.sock_recv(self._socket, 1024)
-            print('Received: {0} from {1}'.format(data, self.server_address), file=sys.stderr)
-            handle_receive_cb(data, self.server_address)
+        while not self._closed:
+            try:
+                data = await loop.sock_recv(self._socket, 1024)
+                print('Received: {0} from {1}'.format(data, self.server_address), file=sys.stderr)
+                handle_receive_cb(data, self.server_address)
+            except OSError:
+                await asyncio.sleep(0.1)
+                continue
 
     async def _handle_send(self, loop):
-        while True:
+        while not self._closed:
             # Send data to client asynchronously
             data = await self._send_queue.get()
             try:

--- a/auctionsystem/tcp/client.py
+++ b/auctionsystem/tcp/client.py
@@ -25,8 +25,6 @@ class TCPClient:
     def close_connections(self):
         print('Closing connections to this TCP client', file=sys.stderr)
         # Stop listening for new data to send or receive
-        # for task in self.tasks:
-        #     task.cancel()
         self._closed = True
 
         # Close this client's socket

--- a/auctionsystem/tcp/server.py
+++ b/auctionsystem/tcp/server.py
@@ -14,11 +14,14 @@ class TCPServer:
             self._send_queue = asyncio.Queue(loop=loop)
             self.tasks = []
 
+            self._closed = False
+
             # Create listener to receive data
             self.tasks.append(loop.create_task(self._handle_receive(loop, handle_receive_cb)))
             self.tasks.append(loop.create_task(self._handle_send(loop)))
 
         def __del__(self):
+            self._closed = True
             self.sock.close()
             # Stop listening for new data to send or receive
             for task in self.tasks:
@@ -30,13 +33,13 @@ class TCPServer:
             self._send_queue.put_nowait(data)
 
         async def _handle_receive(self, loop, handle_receive_cb):
-            while True:
+            while not self._closed:
                 data = await loop.sock_recv(self.sock, 1024)
                 self.logger.info('Received: {0} from {1}'.format(data, self.addr))
                 handle_receive_cb(data, self.addr)
 
         async def _handle_send(self, loop):
-            while True:
+            while not self._closed:
                 # Send data to client asynchronously
                 data = await self._send_queue.get()
                 try:
@@ -52,6 +55,8 @@ class TCPServer:
         self.logger = logger
         self.conn = {}  # Dict of all valid connections
         self._socket = self.get_tcp_server_socket(self.logger, port_number)
+
+        self._closed = False
 
         # Start listener for new connections
         self.receive_task = loop.create_task(self._handle_new_connections(loop, handle_receive_cb))
@@ -88,7 +93,7 @@ class TCPServer:
         return sock
 
     async def _handle_new_connections(self, loop, handle_receive_cb):
-        while True:
+        while not self._closed:
             conn, addr = await loop.sock_accept(self._socket)
             connection = self.Connection(loop, conn, addr, handle_receive_cb, self.logger)
             self.conn[addr] = connection

--- a/auctionsystem/tcp/server.py
+++ b/auctionsystem/tcp/server.py
@@ -24,8 +24,6 @@ class TCPServer:
             self._closed = True
             self.sock.close()
             # Stop listening for new data to send or receive
-            for task in self.tasks:
-                task.cancel()
 
         def send(self, data):
             # Add data to async queue to ensure it's sent in order

--- a/auctionsystem/udp/client.py
+++ b/auctionsystem/udp/client.py
@@ -20,7 +20,6 @@ class UDPClient:
         if self._socket:
             print('Closing socket', file=sys.stderr)
             self._closed = True
-            # self.task.cancel()
             self._socket.close()
 
     async def _handle_receive(self, loop, handle_receive_cb):

--- a/auctionsystem/udp/client.py
+++ b/auctionsystem/udp/client.py
@@ -20,15 +20,16 @@ class UDPClient:
         if self._socket:
             print('Closing socket', file=sys.stderr)
             self._closed = True
-            self.task.cancel()
+            # self.task.cancel()
             self._socket.close()
 
     async def _handle_receive(self, loop, handle_receive_cb):
         if self._socket:
-            while True:
+            while not self._closed:
                 data, addr = await self._async_recvfrom(loop, 1024)
-                print('From {0} received: {1}'.format(addr, data), file=sys.stderr)
-                handle_receive_cb(data, addr)
+                if data:
+                    print('From {0} received: {1}'.format(addr, data), file=sys.stderr)
+                    handle_receive_cb(data, addr)
 
     def _async_recvfrom(self, loop, n_bytes, future=None, registered=False):
         # asyncio doesn't have an asynchronous version of recvfrom so this is an implementation of it

--- a/auctionsystem/udp/server.py
+++ b/auctionsystem/udp/server.py
@@ -21,7 +21,6 @@ class UDPServer:
     def close_socket(self):
         self.logger.info('Closing socket')
         self._closed = True
-        self.task.cancel()
         self._socket.close()
 
     @staticmethod
@@ -50,12 +49,12 @@ class UDPServer:
         return sock
 
     async def _handle_receive(self, loop, handle_receive_cb):
-        while True:
+        while not self._closed:
             data, addr = await self._async_recvfrom(loop, 1024)
             if (data, addr) == (None, None):
                 # This means we received an ICMP Error, ignore this data
                 continue
-                self.logger.info('From {0} received: {1}'.format(addr, data))
+            self.logger.info('From {0} received: {1}'.format(addr, data))
             handle_receive_cb(data, addr)
 
     def _async_recvfrom(self, loop, n_bytes, future=None, registered=False):

--- a/gui/auction_client_gui.py
+++ b/gui/auction_client_gui.py
@@ -25,6 +25,7 @@ class AuctionClientGui(tk.Frame):
         # Fields
         self.client = None
         self.offers_history = {}
+        self.registered = False
 
         # Row 0
         self.reg_panel = RegisterPanel(master=self, register_cb=self.register_cb)
@@ -151,6 +152,8 @@ class AuctionClientGui(tk.Frame):
     # Called when receiving registered or dereg confirmed messages
     def activate_client_interface(self, activate):
 
+        self.registered = activate
+
         # When the interface is active, the register panel is inaccessible and the rest is
         # vice-versa when it's no longer active
 
@@ -167,7 +170,8 @@ class AuctionClientGui(tk.Frame):
             self.new_offer_panel.clear()
 
     def set_reg_panel_response(self, response):
-        self.reg_panel.set_response_text(helper.get_formatted_display_text(response))
+        if not self.registered:
+            self.reg_panel.set_response_text(helper.get_formatted_display_text(response))
 
     def set_dereg_panel_response(self, response):
         self.dereg_panel.set_response_text(helper.get_formatted_display_text(response))


### PR DESCRIPTION
- Made item num a string value
- If client is registered successfully, unregistered error messages don't appear
- Replaced "while True" with "while self._closed" for UDP and TCP servers and clients
- Added KeyboardInterrupt handling for server (note: I wasn't really able to test it as when it is running I can't seem to interrupt it in the python console anyway).